### PR TITLE
Fix a bug with socket options params vsn value being overridden

### DIFF
--- a/lib/src/phoenix_socket_options.dart
+++ b/lib/src/phoenix_socket_options.dart
@@ -5,7 +5,11 @@ class PhoenixSocketOptions {
     this.heartbeatIntervalMs = 30000,
     this.reconnectAfterMs,
     this.params,
-  });
+  }) {
+    params ??= {};
+    params['vsn'] = '2.0.0';
+  }
+
 
   /// How long to wait for a response
   int timeout;
@@ -17,5 +21,5 @@ class PhoenixSocketOptions {
   List<int> reconnectAfterMs;
 
   /// Parameters sent to your Phoenix backend on connection.
-  Map<String, String> params = {"vsn": "2.0.0"};
+  Map<String, String> params;
 }

--- a/test/phoenix_socket_options_test.dart
+++ b/test/phoenix_socket_options_test.dart
@@ -1,0 +1,46 @@
+@TestOn("vm")
+
+import 'package:test/test.dart';
+import 'package:phoenix_wings/src/phoenix_socket_options.dart';
+
+void main() {
+  test("Can create socket options with default values", () {
+    final options = new PhoenixSocketOptions();
+    expect(options.timeout, 10000);
+    expect(options.heartbeatIntervalMs, 30000);
+    expect(options.reconnectAfterMs, null);
+    expect(options.params, {"vsn": "2.0.0"});
+  });
+
+  test("Can create socket options with overridden timeout", () {
+    final options = new PhoenixSocketOptions(timeout: 99);
+    expect(options.timeout, 99);
+    expect(options.heartbeatIntervalMs, 30000);
+    expect(options.reconnectAfterMs, null);
+    expect(options.params, {"vsn": "2.0.0"});
+  });
+
+  test("Can create socket options with overridden heartbeatIntervalMs", () {
+    final options = new PhoenixSocketOptions(heartbeatIntervalMs: 99);
+    expect(options.timeout, 10000);
+    expect(options.heartbeatIntervalMs, 99);
+    expect(options.reconnectAfterMs, null);
+    expect(options.params, {"vsn": "2.0.0"});
+  });
+
+  test("Cannot override socket options with vsn params", () {
+    final options = new PhoenixSocketOptions(params: {});
+    expect(options.timeout, 10000);
+    expect(options.heartbeatIntervalMs, 30000);
+    expect(options.reconnectAfterMs, null);
+    expect(options.params, {"vsn": "2.0.0"});
+  });
+
+  test("Can create socket options with overridden params", () {
+    final options = new PhoenixSocketOptions(params: {"token": "test"});
+    expect(options.timeout, 10000);
+    expect(options.heartbeatIntervalMs, 30000);
+    expect(options.reconnectAfterMs, null);
+    expect(options.params, {"token": "test", "vsn": "2.0.0"});
+  });
+}


### PR DESCRIPTION
The current version of phoenix_wings appears to be broken when the socket options contractor is called without a params value.  The default params value is set to null then the socket is created and falls back to version 1.0.0 of the protocol which is incompatible with phoenix_wings.

I've hardcoded the constructor to set vsn to 2.0.0.  Another path is to throw an exception but I opted for hardcoding the protocol vsn to 2.0.0.