### PR TITLE
Remove casts in joins on presence

### DIFF
--- a/lib/src/phoenix_presence.dart
+++ b/lib/src/phoenix_presence.dart
@@ -105,10 +105,10 @@ class PhoenixPresence {
       state[key] = newPresence;
       if (currentPresence != null) {
         var joinedRefs = state[key]['metas']
-          .where((Map<String, dynamic> meta) => meta.containsKey('phx_ref'))
-          .map((Map<String, dynamic> meta) => meta['phx_ref']);
+          .where((meta) => meta.containsKey('phx_ref') as bool)
+          .map((meta) => meta['phx_ref']);
 
-        var curMetas = List<Map<String, dynamic>>.from(currentPresence['metas'].where((meta) => !joinedRefs.contains(meta['phx_ref'])));
+        var curMetas = List.from(currentPresence['metas'].where((meta) => !joinedRefs.contains(meta['phx_ref'])));
         state[key]['metas'].insertAll(0, curMetas);
       } 
       onJoinCallback(key, currentPresence, newPresence);


### PR DESCRIPTION
While running in Flutter 3.10.2, these lines were throwing errors due to an inability of flutter to cast properly. I noted that the code just below this does not cast anything. I removed the casts (and matched the code pattern below this) and the errors have been resolved.